### PR TITLE
Added a bucket attribute for sidecar:derivative

### DIFF
--- a/harvestor/httpclient/sidecar.go
+++ b/harvestor/httpclient/sidecar.go
@@ -27,6 +27,7 @@ type PostSidecarAttributes struct {
 type PostSidecarDerivativeAttributes struct {
 	DerivativeType string `json:"derivativeType"`
 	DcType         string `json:"dcType"`
+	Bucket         string `json:"bucket"`
 	FileIdentifier string `json:"fileIdentifier"`
 }
 
@@ -210,6 +211,7 @@ func getDerivativePostData(upload *db.Upload, meta *db.Meta) *PostSidecarDerivat
 	postAttributes := &PostSidecarDerivativeAttributes{
 		"LARGE_IMAGE",
 		"Image",
+		"cnc",
 		upload.GetFileIdentifier(),
 	}
 

--- a/harvestor/httpclient/sidecar.go
+++ b/harvestor/httpclient/sidecar.go
@@ -211,7 +211,7 @@ func getDerivativePostData(upload *db.Upload, meta *db.Meta) *PostSidecarDerivat
 	postAttributes := &PostSidecarDerivativeAttributes{
 		"LARGE_IMAGE",
 		"Image",
-		"cnc",
+		upload.GetBucket(),
 		upload.GetFileIdentifier(),
 	}
 


### PR DESCRIPTION
Added new attribute:bucket to golang struct : PostSidecarDerivativeAttributes
The bucket attribute is used for the same purpose as for Metadata
@cgendreau please verify an example of the payload bellow.

/sidecar.go:159 harvestor/httpclient.postSideCarDerivative()  derivative record has been posted : {
	"data": {
		"type": "derivative",
		"attributes": {
			"derivativeType": "LARGE_IMAGE",
			"dcType": "Image",
			"bucket": "cnc",
			"fileIdentifier": "ddd39a76-0b03-47fd-97f0-93762d50f879"
		},
		"relationships": {
			"acDerivedFrom": {
				"data": {
					"id": "7037e004-68de-4909-83e3-e987433ed921",
					"type": "metadata"
				}
			}
		}
	}
} 

Thank you